### PR TITLE
Move compiler passes to `compile/`

### DIFF
--- a/private/compile.rkt
+++ b/private/compile.rkt
@@ -15,13 +15,9 @@
  (for-template "forms.rkt"))
 
 (provide
- build-conj
- reorder-conjunction
- reorder-conjunctions
- generate-code
- generate-relation
  compiled-names
- compile-run)
+ compile-run
+ compile-relation)
 
 
 
@@ -138,4 +134,10 @@
      (define reordered (reorder-conjunctions #'g))
      (define compiled (generate-code reordered))
      #`(mk:run* (q ...) #,compiled)]))
+
+(define/hygienic (compile-relation rel) #:expression
+  (syntax-parse rel
+    [(relation (x ...) g)
+     (define reordered (reorder-conjunctions this-syntax))
+     (generate-relation reordered)]))
 

--- a/private/compile.rkt
+++ b/private/compile.rkt
@@ -1,22 +1,12 @@
 #lang racket/base
 
-(require
- ee-lib
- syntax/stx
- syntax/parse
- syntax/id-table
- racket/math
- (for-template "runtime.rkt")
- (for-template racket/base)
- (for-template (prefix-in mk: minikanren))
- (only-in syntax/parse [define/syntax-parse def/stx])
- "syntax-classes.rkt"
- "env-rep.rkt"
- (for-template "forms.rkt")
-
- ; Compiler Passes
- "compile/reorder-conj.rkt"
- "compile/generate-code.rkt")
+(require (for-template racket/base)
+         ee-lib
+         syntax/parse
+         (only-in syntax/parse
+                  (define/syntax-parse def/stx))
+         "compile/generate-code.rkt"
+         "compile/reorder-conj.rkt")
 
 (provide
  compiled-names

--- a/private/compile.rkt
+++ b/private/compile.rkt
@@ -5,6 +5,7 @@
  syntax/stx
  syntax/parse
  syntax/id-table
+ racket/math
  (for-template "runtime.rkt")
  (for-template racket/base)
  (for-template (prefix-in mk: minikanren))
@@ -19,7 +20,8 @@
  reorder-conjunctions
  generate-code
  generate-relation
- compiled-names)
+ compiled-names
+ compile-run)
 
 
 
@@ -125,4 +127,15 @@
   (syntax-parse stx
     [(_ (x^ ...) g^)
      #`(relation-value (lambda (x^ ...) #,(generate-code #'g^)))]))
+
+(define/hygienic (compile-run query) #:expression
+  (syntax-parse query
+    [(run n (q ...) g)
+     (define reordered (reorder-conjunctions #'g))
+     (define compiled (generate-code reordered))
+     #`(mk:run (check-natural n #'n) (q ...) #,compiled)]
+    [(run* (q ...) g)
+     (define reordered (reorder-conjunctions #'g))
+     (define compiled (generate-code reordered))
+     #`(mk:run* (q ...) #,compiled)]))
 

--- a/private/compile.rkt
+++ b/private/compile.rkt
@@ -15,90 +15,24 @@
  (for-template "forms.rkt")
 
  ; Compiler Passes
- "compile/reorder-conj.rkt")
+ "compile/reorder-conj.rkt"
+ "compile/generate-code.rkt")
 
 (provide
  compiled-names
  compile-run
  compile-relation)
 
-; Code generation
 
-(define compiled-names (make-free-id-table))
-
-(define constraint-impls
-  (make-free-id-table
-   (hash #'symbolo #'mk:symbolo
-         #'stringo #'mk:stringo
-         #'numbero #'mk:numbero
-         #'== #'mk:==
-         #'=/= #'mk:=/=
-         #'absento #'mk:absento)))
-
-(define/hygienic (generate-code stx) #:expression
+(define/hygienic (compile-run stx) #:expression
   (syntax-parse stx
-    #:literal-sets (mk-literals)
-    #:literals (quote cons)
-    ; core terms
-    [(#%lv-ref v:id)
-     #'v]
-    [(rkt-term e)
-     #'(check-term e #'e)]
-    [(#%term-datum l:number)
-     #'(quote l)]
-    [(#%term-datum l:string)
-     #'(quote l)]
-    [(#%term-datum l:boolean)
-     #'(quote l)]
-    [(quote d)
-     #'(quote d)]
-    [(cons t1:term/c t2:term/c)
-     #`(cons #,(generate-code #'t1) #,(generate-code #'t2))]
-    
-    ; core goals
-    [(c:unary-constraint t)
-     (def/stx c^ (free-id-table-ref constraint-impls #'c))
-     #`(c^ #,(generate-code #'t))]
-    [(c:binary-constraint t1 t2)
-     (def/stx c^ (free-id-table-ref constraint-impls #'c))
-     #`(c^ #,(generate-code #'t1) #,(generate-code #'t2))]
-    [(#%rel-app n:id t ...)
-     (def/stx n^ (free-id-table-ref compiled-names #'n))
-     #`((relation-value-proc n^) #,@ (stx-map generate-code #'(t ...)))]
-    [(disj g1 g2)
-     #`(mk:conde
-        [#,(generate-code #'g1)]
-        [#,(generate-code #'g2)])]
-    [(conj g1 g2)
-     #`(mk:fresh ()
-                 #,(generate-code #'g1)
-                 #,(generate-code #'g2))]
-    [(fresh (x:id ...) g)
-     #`(mk:fresh (x ...) #,(generate-code #'g))]
-    [(apply-relation e t ...)
-     #`((relation-value-proc (check-relation e #'e))
-        #,@(stx-map generate-code #'(t ...)))]
-    
-    ))
+    [(~or (run _ (_ ...) _)
+          (run* (_ ...) _))
+     (define reordered (reorder-conj/run this-syntax))
+     (generate-run reordered)]))
 
-(define/hygienic (generate-relation stx) #:expression
+(define/hygienic (compile-relation stx) #:expression
   (syntax-parse stx
-    [(_ (x^ ...) g^)
-     #`(relation-value (lambda (x^ ...) #,(generate-code #'g^)))]))
-
-(define/hygienic (compile-run query) #:expression
-  (syntax-parse query
-    [(run n (q ...) g)
-     (define reordered (reorder-conj/run #'g))
-     (define compiled (generate-code reordered))
-     #`(mk:run (check-natural n #'n) (q ...) #,compiled)]
-    [(run* (q ...) g)
-     (define reordered (reorder-conj/run #'g))
-     (define compiled (generate-code reordered))
-     #`(mk:run* (q ...) #,compiled)]))
-
-(define/hygienic (compile-relation rel) #:expression
-  (syntax-parse rel
     [(relation (x ...) g)
      (define reordered (reorder-conj/rel this-syntax))
      (generate-relation reordered)]))

--- a/private/compile/generate-code.rkt
+++ b/private/compile/generate-code.rkt
@@ -1,18 +1,16 @@
 #lang racket/base
 
-(require
- ee-lib
- syntax/stx
- syntax/parse
- syntax/id-table
- racket/math
- (for-template "../runtime.rkt")
- (for-template racket/base)
- (for-template (prefix-in mk: minikanren))
- (only-in syntax/parse [define/syntax-parse def/stx])
- "../syntax-classes.rkt"
- "../env-rep.rkt"
- (for-template "../forms.rkt"))
+(require (for-template (prefix-in mk: minikanren)
+                       racket/base
+                       "../forms.rkt"
+                       "../runtime.rkt")
+         ee-lib
+         syntax/id-table
+         syntax/parse
+         (only-in syntax/parse
+                  (define/syntax-parse def/stx))
+         syntax/stx
+         "../syntax-classes.rkt")
 
 (provide generate-relation
          generate-run

--- a/private/compile/generate-code.rkt
+++ b/private/compile/generate-code.rkt
@@ -43,32 +43,15 @@
   (syntax-parse stx
     #:literal-sets (mk-literals)
     #:literals (quote cons)
-    ; core terms
-    [(#%lv-ref v:id)
-     #'v]
-    [(rkt-term e)
-     #'(check-term e #'e)]
-    [(#%term-datum l:number)
-     #'(quote l)]
-    [(#%term-datum l:string)
-     #'(quote l)]
-    [(#%term-datum l:boolean)
-     #'(quote l)]
-    [(quote d)
-     #'(quote d)]
-    [(cons t1:term/c t2:term/c)
-     #`(cons #,(generate-goal #'t1) #,(generate-goal #'t2))]
-    
-    ; core goals
     [(c:unary-constraint t)
      (def/stx c^ (free-id-table-ref constraint-impls #'c))
-     #`(c^ #,(generate-goal #'t))]
+     #`(c^ #,(generate-term #'t))]
     [(c:binary-constraint t1 t2)
      (def/stx c^ (free-id-table-ref constraint-impls #'c))
-     #`(c^ #,(generate-goal #'t1) #,(generate-goal #'t2))]
+     #`(c^ #,(generate-term #'t1) #,(generate-term #'t2))]
     [(#%rel-app n:id t ...)
      (def/stx n^ (free-id-table-ref compiled-names #'n))
-     #`((relation-value-proc n^) #,@ (stx-map generate-goal #'(t ...)))]
+     #`((relation-value-proc n^) #,@ (stx-map generate-term #'(t ...)))]
     [(disj g1 g2)
      #`(mk:conde
         [#,(generate-goal #'g1)]
@@ -81,11 +64,22 @@
      #`(mk:fresh (x ...) #,(generate-goal #'g))]
     [(apply-relation e t ...)
      #`((relation-value-proc (check-relation e #'e))
-        #,@(stx-map generate-goal #'(t ...)))]
-    
-    ))
+        #,@(stx-map generate-term #'(t ...)))]))
 
 (define/hygienic (generate-term stx) #:expression
-  #'())
-
-
+  (syntax-parse stx
+    #:literal-sets (mk-literals)
+    #:literals (quote cons)
+    [(#%lv-ref v:id) #'v]
+    [(rkt-term e)
+     #'(check-term e #'e)]
+    [(#%term-datum l:number)
+     #'(quote l)]
+    [(#%term-datum l:string)
+     #'(quote l)]
+    [(#%term-datum l:boolean)
+     #'(quote l)]
+    [(quote d)
+     #'(quote d)]
+    [(cons t1:term/c t2:term/c)
+     #`(cons #,(generate-term #'t1) #,(generate-term #'t2))]))

--- a/private/compile/generate-code.rkt
+++ b/private/compile/generate-code.rkt
@@ -1,0 +1,93 @@
+#lang racket/base
+
+(require
+ ee-lib
+ syntax/stx
+ syntax/parse
+ syntax/id-table
+ racket/math
+ (for-template "../runtime.rkt")
+ (for-template racket/base)
+ (for-template (prefix-in mk: minikanren))
+ (only-in syntax/parse [define/syntax-parse def/stx])
+ "../syntax-classes.rkt"
+ "../env-rep.rkt"
+ (for-template "../forms.rkt"))
+
+(provide generate-relation
+         generate-run
+         compiled-names)
+
+(define/hygienic (generate-relation stx) #:expression
+  (syntax-parse stx
+    [(_ (x^ ...) g^)
+     #`(relation-value (lambda (x^ ...) #,(generate-goal #'g^)))]))
+
+(define/hygienic (generate-run stx) #:expression
+  (syntax-parse stx
+    [(run n (q ...) g)
+     #`(mk:run (check-natural n #'n) (q ...) #,(generate-goal #'g))]
+    [(run* (q ...) g)
+     #`(mk:run* (q ...) #,(generate-goal #'g))]))
+
+(define compiled-names (make-free-id-table))
+
+(define constraint-impls
+  (make-free-id-table
+   (hash #'symbolo #'mk:symbolo
+         #'stringo #'mk:stringo
+         #'numbero #'mk:numbero
+         #'== #'mk:==
+         #'=/= #'mk:=/=
+         #'absento #'mk:absento)))
+
+(define/hygienic (generate-goal stx) #:expression
+  (syntax-parse stx
+    #:literal-sets (mk-literals)
+    #:literals (quote cons)
+    ; core terms
+    [(#%lv-ref v:id)
+     #'v]
+    [(rkt-term e)
+     #'(check-term e #'e)]
+    [(#%term-datum l:number)
+     #'(quote l)]
+    [(#%term-datum l:string)
+     #'(quote l)]
+    [(#%term-datum l:boolean)
+     #'(quote l)]
+    [(quote d)
+     #'(quote d)]
+    [(cons t1:term/c t2:term/c)
+     #`(cons #,(generate-goal #'t1) #,(generate-goal #'t2))]
+    
+    ; core goals
+    [(c:unary-constraint t)
+     (def/stx c^ (free-id-table-ref constraint-impls #'c))
+     #`(c^ #,(generate-goal #'t))]
+    [(c:binary-constraint t1 t2)
+     (def/stx c^ (free-id-table-ref constraint-impls #'c))
+     #`(c^ #,(generate-goal #'t1) #,(generate-goal #'t2))]
+    [(#%rel-app n:id t ...)
+     (def/stx n^ (free-id-table-ref compiled-names #'n))
+     #`((relation-value-proc n^) #,@ (stx-map generate-goal #'(t ...)))]
+    [(disj g1 g2)
+     #`(mk:conde
+        [#,(generate-goal #'g1)]
+        [#,(generate-goal #'g2)])]
+    [(conj g1 g2)
+     #`(mk:fresh ()
+                 #,(generate-goal #'g1)
+                 #,(generate-goal #'g2))]
+    [(fresh (x:id ...) g)
+     #`(mk:fresh (x ...) #,(generate-goal #'g))]
+    [(apply-relation e t ...)
+     #`((relation-value-proc (check-relation e #'e))
+        #,@(stx-map generate-goal #'(t ...)))]
+    
+    ))
+
+(define/hygienic (generate-term stx) #:expression
+  #'())
+
+

--- a/private/compile/reorder-conj.rkt
+++ b/private/compile/reorder-conj.rkt
@@ -1,0 +1,60 @@
+#lang racket/base
+
+(require
+ ee-lib
+ syntax/stx
+ syntax/parse
+ syntax/id-table
+ (for-template "../runtime.rkt")
+ (for-template racket/base)
+ (for-template (prefix-in mk: minikanren))
+ (only-in syntax/parse [define/syntax-parse def/stx])
+ "../syntax-classes.rkt"
+ "../env-rep.rkt"
+ (for-template "../forms.rkt"))
+
+(provide reorder-conj/rel
+         reorder-conj/run)
+
+(define (reorder-conj/rel stx)
+  (reorder-conjunctions stx))
+
+(define (reorder-conj/run stx)
+  (reorder-conjunctions stx))
+
+(define (build-conj l)
+  (when (null? l) (error 'build-conj "requires at least one item"))
+  (let recur ([l (reverse l)])
+    (if (= (length l) 1)
+        (car l)
+        #`(conj
+           #,(recur (cdr l))
+           #,(car l)))))
+
+(define (reorder-conjunction stx)
+  (define lvars '())
+  (define constraints '())
+  (define others '())
+  (let recur ([stx stx])
+    (syntax-parse stx #:literals (conj fresh ==)
+                  [(conj g1 g2) (recur #'g1) (recur #'g2)]
+                  [(fresh (x:id ...) g)
+                   (set! lvars (cons (syntax->list #'(x ...)) lvars))
+                   (recur #'g)]
+                  [(~or (c:unary-constraint t)
+                        (c:binary-constraint t1 t2))
+                   (set! constraints (cons this-syntax constraints))]
+                  [_ (set! others (cons (reorder-conjunctions this-syntax) others))]))
+  (let ([lvars (apply append (reverse lvars))]
+        [body (build-conj (append (reverse constraints) (reverse others)))])
+    (if (null? lvars)
+        body
+        #`(fresh #,lvars #,body))))
+
+(define (reorder-conjunctions stx)
+  (define (maybe-reorder stx)
+    (syntax-parse stx
+      #:literals (conj fresh)
+      [((~or conj fresh) . _) (reorder-conjunction this-syntax)]
+      [_ this-syntax]))
+  (map-transform maybe-reorder stx))

--- a/private/compile/reorder-conj.rkt
+++ b/private/compile/reorder-conj.rkt
@@ -1,17 +1,12 @@
 #lang racket/base
 
-(require
- ee-lib
- syntax/stx
- syntax/parse
- syntax/id-table
- (for-template "../runtime.rkt")
- (for-template racket/base)
- (for-template (prefix-in mk: minikanren))
- (only-in syntax/parse [define/syntax-parse def/stx])
- "../syntax-classes.rkt"
- "../env-rep.rkt"
- (for-template "../forms.rkt"))
+(require (for-template racket/base
+                       "../forms.rkt")
+         ee-lib
+         syntax/parse
+         (only-in syntax/parse
+                  (define/syntax-parse def/stx))
+         "../syntax-classes.rkt")
 
 (provide reorder-conj/rel
          reorder-conj/run)

--- a/private/interface-macros.rkt
+++ b/private/interface-macros.rkt
@@ -52,9 +52,7 @@
      (with-scope sc
        (def/stx (x^ ...) (bind-logic-vars! (add-scope #'(b.x ...) sc)))
        (define expanded (expand-goal (add-scope #'g sc)))
-       (define reordered (reorder-conjunctions expanded))
-       (define compiled (generate-code reordered))
-       #`(mk:run (check-natural n #'n) (x^ ...) #,compiled))]))
+       (compile-run #`(run n (x^ ...) #,expanded)))]))
 
 (define-syntax run*
   (syntax-parser
@@ -64,9 +62,7 @@
      (with-scope sc
        (def/stx (x^ ...) (bind-logic-vars! (add-scope #'(b.x ...) sc)))
        (define expanded (expand-goal (add-scope #'g sc)))
-       (define reordered (reorder-conjunctions expanded))
-       (define compiled (generate-code reordered))
-       #`(mk:run* (x^ ...) #,compiled))]))
+       (compile-run #`(run* (x^ ...) #,expanded)))]))
 
 (define-syntax relation
   (syntax-parser

--- a/private/interface-macros.rkt
+++ b/private/interface-macros.rkt
@@ -71,13 +71,12 @@
       (_ b:bindings/c g:goal/c))
      ; some awkwardness to let us capture the expanded and optimized mk code
      (define expanded (expand-relation this-syntax))
-     (define reordered (reorder-conjunctions expanded))
      (define name (syntax-property this-syntax 'name))
      (when name
        (free-id-table-set! expanded-relation-code
                            name
-                           reordered))
-     (generate-relation reordered)]))
+                           expanded))
+     (compile-relation expanded)]))
 
 (define-syntax define-relation
   (syntax-parser


### PR DESCRIPTION
This PR:

- creates two 'entry points' to the compiler for the interface macros to use: compile-run and compile-relation
- moves each compiler pass into its own module in the new compile/ directory
- adds to each pass a dedicated function for both entry points (i.e. one function for run and one function for relation) to execute the pass

cc @michaelballantyne, I accidentally opened this on your repo the first time