### PR TITLE
Add `ir-rel` Form

### DIFF
--- a/private/compile.rkt
+++ b/private/compile.rkt
@@ -30,7 +30,7 @@
 
 (define/hygienic (compile-relation stx) #:expression
   (syntax-parse stx
-    [(relation (x ...) g)
+    [(ir-rel (x ...) g)
      (define reordered (reorder-conj/rel this-syntax))
      (generate-relation reordered)]))
 

--- a/private/expand.rkt
+++ b/private/expand.rkt
@@ -134,7 +134,7 @@
      (with-scope sc
        (def/stx (x^ ...) (bind-logic-vars! (add-scope #'(x ...) sc)))
        (def/stx g^ (expand-goal (add-scope #'g sc)))
-       (qstx/rc (relation (x^ ...) g^)))]))
+       (qstx/rc (ir-rel (x^ ...) g^)))]))
   
 
  

--- a/private/forms.rkt
+++ b/private/forms.rkt
@@ -26,4 +26,6 @@
 
    #%rel-app
    rkt-term
-   apply-relation])
+   apply-relation
+
+   ir-rel])


### PR DESCRIPTION
Add ir-rel to our list of forms, so that we have a name to use in tests for relations.

The following test:

```
(progs-equal? (generate-prog (relation ((~binder q)) (== q q)))
              (generate-prog (relation ((~binder q)) (== q q))))
```
Fails on relation not being free-identifier=? to relation. Substituting relation with ir-rel succeeds.